### PR TITLE
클래스 빈칸 없애 렌더링 최적화 완료

### DIFF
--- a/src/components/SideBar/SideBarPages.js
+++ b/src/components/SideBar/SideBarPages.js
@@ -168,8 +168,8 @@ const printPage = (
       if (openedDetail.has(String(list.id))) icon = "keyboard_arrow_down";
       else icon = "keyboard_arrow_right";
     }
-    content += `<li class="sidebar__pages--detail sidebar__pages--detail-click ${
-      list.id == selected ? "highlight" : ""
+    content += `<li class="sidebar__pages--detail sidebar__pages--detail-click${
+      list.id == selected ? " highlight" : ""
     }" data-id="${list.id}" data-action="select" style="--depth:${depth}">
         <div class="sidebar__pages--detail-contents">
           <button class="sidebar__pages--detail-button sidebar__pages--detail-click" data-action="toggle">


### PR DESCRIPTION
## 📌 이슈 번호

close #19 

## 🚀 구현 내용
기존에 빈칸이 있을 때 class의 내용이 다르다 판단이 되어 렌더링 되는 문제가 발생함.
이를 방지하기 위해 수정 완료.
(2부분만 변경되야 하는데 4부분이 변경되는 사이드 이펙트 발생)
<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
